### PR TITLE
ci: remove conditional on docker/login-action step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   workflow_dispatch:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: 0 0 * * *
 
 env:
   REGISTRY: ghcr.io
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/checkout@v3.5.0
       - uses: docker/setup-qemu-action@v2.1.0
       - uses: docker/setup-buildx-action@v2.5.0
-      - if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2.1.0
+      - uses: docker/login-action@v2.1.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
This PR removes the conditional on the `docker/login-action` step as it was breaking the caching mechanism for the `docker/build-push-action` stage.