### PR TITLE
build: cache layers and parallelize Docker image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,21 @@
 venv
 .git
 .envs/
+
+# Python virtualenv and caches (host-built, wrong arch, slow to copy)
+.venv
+__pycache__/
+*.py[cod]
+.ruff_cache
+.mypy_cache
+.pytest_cache
+.coverage
+.coverage.*
+htmlcov/
+
+# Node
+node_modules
+
+# Collected static / build artifacts
+staticfiles/
+.vscode

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -39,7 +39,7 @@ ENV PYTHONPATH="${APP_HOME}/.venv/lib/python3.13/site-packages:$PYTHONPATH"
 # Install dependencies first (cached unless pyproject.toml/uv.lock change).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
     uv sync --no-install-project
 
 # Entrypoint and start scripts: stable, so copy before the source tree to keep
@@ -57,7 +57,7 @@ COPY . ${APP_HOME}
 # Install the project itself (source changes only invalidate from here down).
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
     uv sync
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/local/django/Dockerfile
+++ b/compose/local/django/Dockerfile
@@ -11,31 +11,21 @@ WORKDIR ${APP_HOME}
 # we need to move the virtualenv outside of the $APP_HOME directory because it will be overriden by the docker compose mount
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=0
 
-# Install apt packages
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  # dependencies for building Python packages
-  build-essential \
-  # psycopg dependencies
-  libpq-dev \
-  gettext \
-  wait-for-it
-
-# Requirements are installed here to ensure they will be cached.
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
-    uv sync --no-install-project
-
-COPY . ${APP_HOME}
-
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
-    uv sync
-
-# devcontainer dependencies and utils
-RUN apt-get update && apt-get install --no-install-recommends -y \
-  sudo git bash-completion nano ssh
+# Install apt packages: build deps plus devcontainer utils, in a single layer.
+# Cache mounts keep downloaded .debs and package lists across rebuilds, so a
+# `just prune` full rebuild does not re-download everything.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update && apt-get install --no-install-recommends -y \
+      # dependencies for building Python packages
+      build-essential \
+      # psycopg dependencies
+      libpq-dev \
+      gettext \
+      wait-for-it \
+      # devcontainer dependencies and utils
+      sudo git bash-completion nano ssh
 
 # Create devcontainer user and add it to sudoers
 RUN groupadd --gid 1000 dev-user \
@@ -46,26 +36,28 @@ RUN groupadd --gid 1000 dev-user \
 ENV PATH="/${APP_HOME}/.venv/bin:$PATH"
 ENV PYTHONPATH="${APP_HOME}/.venv/lib/python3.13/site-packages:$PYTHONPATH"
 
+# Install dependencies first (cached unless pyproject.toml/uv.lock change).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
+    uv sync --no-install-project
+
+# Entrypoint and start scripts: stable, so copy before the source tree to keep
+# them out of the cache-busting COPY below.
 COPY ./compose/production/django/entrypoint /entrypoint
-RUN sed -i 's/\r$//g' /entrypoint
-RUN chmod +x /entrypoint
-
 COPY ./compose/local/django/start /start
-RUN sed -i 's/\r$//g' /start
-RUN chmod +x /start
-
-
 COPY ./compose/local/django/celery/worker/start /start-celeryworker
-RUN sed -i 's/\r$//g' /start-celeryworker
-RUN chmod +x /start-celeryworker
-
 COPY ./compose/local/django/celery/beat/start /start-celerybeat
-RUN sed -i 's/\r$//g' /start-celerybeat
-RUN chmod +x /start-celerybeat
-
 COPY ./compose/local/django/celery/flower/start /start-flower
-RUN sed -i 's/\r$//g' /start-flower
-RUN chmod +x /start-flower
+RUN sed -i 's/\r$//g' /entrypoint /start /start-celeryworker /start-celerybeat /start-flower \
+    && chmod +x /entrypoint /start /start-celeryworker /start-celerybeat /start-flower
 
+COPY . ${APP_HOME}
+
+# Install the project itself (source changes only invalidate from here down).
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=uv.lock,target=uv.lock:rw \
+    uv sync
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -4,7 +4,7 @@ ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
 
 COPY ./package.json ${APP_HOME}
-RUN npm install && npm cache clean --force
+RUN --mount=type=cache,target=/root/.npm npm install
 COPY . ${APP_HOME}
 RUN npm run build
 # define an alias for the specific python version used in this file.
@@ -62,26 +62,12 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 
 COPY --chown=django:django ./compose/production/django/entrypoint /entrypoint
-RUN sed -i 's/\r$//g' /entrypoint
-RUN chmod +x /entrypoint
-
-
 COPY --chown=django:django ./compose/production/django/start /start
-RUN sed -i 's/\r$//g' /start
-RUN chmod +x /start
 COPY --chown=django:django ./compose/production/django/celery/worker/start /start-celeryworker
-RUN sed -i 's/\r$//g' /start-celeryworker
-RUN chmod +x /start-celeryworker
-
-
 COPY --chown=django:django ./compose/production/django/celery/beat/start /start-celerybeat
-RUN sed -i 's/\r$//g' /start-celerybeat
-RUN chmod +x /start-celerybeat
-
-
 COPY --chown=django:django ./compose/production/django/celery/flower/start /start-flower
-RUN sed -i 's/\r$//g' /start-flower
-RUN chmod +x /start-flower
+RUN sed -i 's/\r$//g' /entrypoint /start /start-celeryworker /start-celerybeat /start-flower \
+    && chmod +x /entrypoint /start /start-celeryworker /start-celerybeat /start-flower
 
 # Copy the application from the builder
 COPY --from=python-build-stage --chown=django:django ${APP_HOME} ${APP_HOME}

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 export COMPOSE_FILE := "docker-compose.local.yml"
 
+# Delegate builds to Buildx Bake so the django/postgres/node images build in
+# parallel with shared BuildKit caching.
+export COMPOSE_BAKE := "true"
+
 ## Just does not yet manage signals for subprocesses reliably, which can lead to unexpected behavior.
 ## Exercise caution before expanding its usage in production environments.
 ## For more information, see https://github.com/casey/just/issues/2473 .


### PR DESCRIPTION
## Summary

Speeds up Docker image builds for both local dev and production by improving layer caching, parallelizing the Compose build, and tightening the build context.

## Changes

- **`compose/local/django/Dockerfile`**
  - Merge build deps and devcontainer utils (`sudo git bash-completion nano ssh`) into a single `apt-get` layer, with `apt` cache mounts so a `just prune` full rebuild doesn't re-download `.deb`s.
  - Reorder layers for cache hits: install dependencies (`uv sync --no-install-project`) before copying source; copy the stable entrypoint/start scripts before the cache-busting `COPY . ${APP_HOME}`; install the project itself last so source edits only invalidate the bottom layers.
  - Collapse the per-script `sed`/`chmod` `RUN`s into one.
- **`compose/production/django/Dockerfile`**
  - Use a `--mount=type=cache` for `npm install` instead of `npm cache clean --force`.
  - Collapse the per-script `sed`/`chmod` `RUN`s into one.
- **`justfile`** — set `COMPOSE_BAKE=true` so `just build` delegates to Buildx Bake, building the django/postgres/node images in parallel with shared BuildKit caching.
- **`.dockerignore`** — exclude host-built virtualenvs, Python/tooling caches, `node_modules`, collected static, and `.vscode` from the build context (wrong arch, slow to copy).

## Test plan

- [x] `just prune && just build` builds cleanly from scratch
- [x] A no-op rebuild is fully cached
- [x] A source-only change rebuilds only the bottom layers
- [x] `just up` brings the stack up and the Django container serves requests
